### PR TITLE
feat: add lsquic cflags follow the cmakelists

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,10 +37,10 @@ pub fn build(b: *std.Build) void {
         "-DLSQUIC_CONN_STATS=1",
         "-DLSQUIC_DEVEL=1",
         "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
-        "-fno-sanitize=null",
+        // "-fno-sanitize=null",
     }) catch @panic("OOM");
 
-    if (optimize == .Debug) {
+    if (optimize == .Debug or optimize == .ReleaseSafe) {
         c_flags.appendSlice(&.{ "-O0", "-g3" }) catch @panic("OOM");
     } else {
         c_flags.appendSlice(&.{ "-O3", "-g0" }) catch @panic("OOM");

--- a/build.zig
+++ b/build.zig
@@ -23,29 +23,71 @@ pub fn build(b: *std.Build) void {
 
     const ssl = boringssl.artifact("ssl");
     const crypto = boringssl.artifact("crypto");
-    // const lshpack_c = lshpack_dep.path("lshpack.c");
-    // const lsqpack_c = lsqpack_dep.path("lsqpack.c");
 
-    const lib = b.addLibrary(.{
+    const lib = b.addStaticLibrary(.{
         .name = "lsquic",
-        .linkage = .static,
-
-        .root_module = b.createModule(
-            .{
-                .target = target,
-                .optimize = optimize,
-                .link_libc = true,
-            },
-        ),
+        .target = target,
+        .optimize = optimize,
     });
 
+    var c_flags = std.ArrayList([]const u8).init(b.allocator);
+
+    c_flags.appendSlice(&.{
+        "-DLSQUIC_DEBUG_NEXT_ADV_TICK=1",
+        "-DLSQUIC_CONN_STATS=1",
+        "-DLSQUIC_DEVEL=1",
+        "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
+        "-fno-sanitize=undefined",
+    }) catch @panic("OOM");
+
+    if (optimize == .Debug) {
+        c_flags.appendSlice(&.{ "-O0", "-g3" }) catch @panic("OOM");
+    } else {
+        c_flags.appendSlice(&.{ "-O3", "-g0" }) catch @panic("OOM");
+    }
+
+    if (target.result.os.tag == .windows) {
+        lib.addIncludePath(upstream.path("wincompat"));
+        c_flags.appendSlice(&.{
+            "/W4",                       "/WX",
+            "-DWIN32_LEAN_AND_MEAN",     "-DNOMINMAX",
+            "-D_CRT_SECURE_NO_WARNINGS", "/wd4100",
+            "/wd4115",                   "/wd4116",
+            "/wd4146",                   "/wd4132",
+            "/wd4200",                   "/wd4204",
+            "/wd4244",                   "/wd4245",
+            "/wd4267",                   "/wd4214",
+            "/wd4295",                   "/wd4324",
+            "/wd4334",                   "/wd4456",
+            "/wd4459",                   "/wd4706",
+            "/wd4090",                   "/wd4305",
+        }) catch @panic("OOM");
+    } else {
+        c_flags.appendSlice(&.{
+            "-Wall",
+            "-Wextra",
+            "-Wno-unused-parameter",
+            "-fno-omit-frame-pointer",
+        }) catch @panic("OOM");
+    }
+
+    // --- Linking and Paths ---
+    lib.linkLibC();
     lib.linkLibrary(ssl);
     lib.linkLibrary(crypto);
-    lib.addIncludePath(lshpack_dep.path("deps/xxhash"));
-    lib.addIncludePath(lsqpack_dep.path("deps/xxhash"));
+
+    if (target.result.os.tag == .windows) {
+        lib.linkSystemLibrary("ws2_32");
+    } else {
+        lib.linkSystemLibrary("m");
+        lib.linkSystemLibrary("pthread");
+    }
+
+    lib.addIncludePath(upstream.path("include"));
     lib.addIncludePath(lshpack_dep.path(""));
     lib.addIncludePath(lsqpack_dep.path(""));
-    lib.addIncludePath(upstream.path("include"));
+    lib.addIncludePath(lshpack_dep.path("deps/xxhash"));
+
     lib.installHeadersDirectory(
         upstream.path("include"),
         "",
@@ -53,22 +95,22 @@ pub fn build(b: *std.Build) void {
     );
     lib.installHeader(lsqpack_dep.path("lsqpack.h"), "lsqpack/lsqpack.h");
     lib.installHeader(lshpack_dep.path("lshpack.h"), "lshpack/lshpack.h");
-    lib.installHeader(lsqpack_dep.path("deps/xxhash/xxhash.h"), "lsqpack/xxhash.h");
-    lib.installHeader(lshpack_dep.path("deps/xxhash/xxhash.h"), "lshpack/xxhash.h");
+    lib.installHeader(lshpack_dep.path("deps/xxhash/xxhash.h"), "xxhash.h");
     lib.root_module.addCMacro("XXH_HEADER_NAME", "\"xxhash.h\"");
 
-    lib.addCSourceFiles(.{ .root = upstream.path("src/liblsquic"), .files = lsquic_files });
-    lib.addCSourceFile(.{ .file = lsqpack_dep.path("lsqpack.c") });
-    lib.addCSourceFile(.{ .file = lshpack_dep.path("lshpack.c") });
-    lib.addCSourceFile(.{ .file = lshpack_dep.path("deps/xxhash/xxhash.c") });
-    lib.addCSourceFile(.{ .file = lsqpack_dep.path("deps/xxhash/xxhash.c") });
+    lib.addCSourceFiles(.{
+        .root = upstream.path("src/liblsquic"),
+        .files = lsquic_files,
+        .flags = c_flags.items,
+    });
+    lib.addCSourceFile(.{ .file = lsqpack_dep.path("lsqpack.c"), .flags = c_flags.items });
+    lib.addCSourceFile(.{ .file = lshpack_dep.path("lshpack.c"), .flags = c_flags.items });
+    lib.addCSourceFile(.{ .file = lshpack_dep.path("deps/xxhash/xxhash.c"), .flags = c_flags.items });
 
     b.installArtifact(lib);
 }
 
 const lsquic_files: []const []const u8 = &.{
-    // "common_cert_set_2.c",
-    // "common_cert_set_3.c",
     "ls-sfparser.c",
     "lsquic_adaptive_cc.c",
     "lsquic_alarmset.c",
@@ -152,5 +194,4 @@ const lsquic_files: []const []const u8 = &.{
     "lsquic_varint.c",
     "lsquic_version.c",
     "lsquic_xxhash.c",
-    "lsquic_global.c",
 };

--- a/build.zig
+++ b/build.zig
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) void {
         "-DLSQUIC_CONN_STATS=1",
         "-DLSQUIC_DEVEL=1",
         "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
-        // "-fno-sanitize=null",
+        "-fno-sanitize=undefined",
     }) catch @panic("OOM");
 
     if (optimize == .Debug or optimize == .ReleaseSafe) {

--- a/build.zig
+++ b/build.zig
@@ -40,7 +40,7 @@ pub fn build(b: *std.Build) void {
         "-fno-sanitize=undefined",
     }) catch @panic("OOM");
 
-    if (optimize == .Debug or optimize == .ReleaseSafe) {
+    if (optimize == .Debug) {
         c_flags.appendSlice(&.{ "-O0", "-g3" }) catch @panic("OOM");
     } else {
         c_flags.appendSlice(&.{ "-O3", "-g0" }) catch @panic("OOM");

--- a/build.zig
+++ b/build.zig
@@ -64,6 +64,8 @@ pub fn build(b: *std.Build) void {
         }) catch @panic("OOM");
     } else {
         c_flags.appendSlice(&.{
+            // Lifted from lsquic's CMakeLists.txt
+            // Source: https://github.com/litespeedtech/lsquic/blob/70486141724f85e97b08f510673e29f399bbae8f/CMakeLists.txt#L52-L53
             "-Wall",
             "-Wextra",
             "-Wno-unused-parameter",

--- a/build.zig
+++ b/build.zig
@@ -37,7 +37,7 @@ pub fn build(b: *std.Build) void {
         "-DLSQUIC_CONN_STATS=1",
         "-DLSQUIC_DEVEL=1",
         "-DLSQUIC_WEBTRANSPORT_SERVER_SUPPORT=1",
-        "-fno-sanitize=undefined",
+        "-fno-sanitize=null",
     }) catch @panic("OOM");
 
     if (optimize == .Debug) {
@@ -47,21 +47,22 @@ pub fn build(b: *std.Build) void {
     }
 
     if (target.result.os.tag == .windows) {
-        lib.addIncludePath(upstream.path("wincompat"));
-        c_flags.appendSlice(&.{
-            "/W4",                       "/WX",
-            "-DWIN32_LEAN_AND_MEAN",     "-DNOMINMAX",
-            "-D_CRT_SECURE_NO_WARNINGS", "/wd4100",
-            "/wd4115",                   "/wd4116",
-            "/wd4146",                   "/wd4132",
-            "/wd4200",                   "/wd4204",
-            "/wd4244",                   "/wd4245",
-            "/wd4267",                   "/wd4214",
-            "/wd4295",                   "/wd4324",
-            "/wd4334",                   "/wd4456",
-            "/wd4459",                   "/wd4706",
-            "/wd4090",                   "/wd4305",
-        }) catch @panic("OOM");
+        // When we have a windows test environment, we can enable these flags.
+        // lib.addIncludePath(upstream.path("wincompat"));
+        // c_flags.appendSlice(&.{
+        //     "/W4",                       "/WX",
+        //     "-DWIN32_LEAN_AND_MEAN",     "-DNOMINMAX",
+        //     "-D_CRT_SECURE_NO_WARNINGS", "/wd4100",
+        //     "/wd4115",                   "/wd4116",
+        //     "/wd4146",                   "/wd4132",
+        //     "/wd4200",                   "/wd4204",
+        //     "/wd4244",                   "/wd4245",
+        //     "/wd4267",                   "/wd4214",
+        //     "/wd4295",                   "/wd4324",
+        //     "/wd4334",                   "/wd4456",
+        //     "/wd4459",                   "/wd4706",
+        //     "/wd4090",                   "/wd4305",
+        // }) catch @panic("OOM");
     } else {
         c_flags.appendSlice(&.{
             // Lifted from lsquic's CMakeLists.txt
@@ -79,7 +80,8 @@ pub fn build(b: *std.Build) void {
     lib.linkLibrary(crypto);
 
     if (target.result.os.tag == .windows) {
-        lib.linkSystemLibrary("ws2_32");
+        // Uncomment these when we have a windows test environment.
+        // lib.linkSystemLibrary("ws2_32");
     } else {
         lib.linkSystemLibrary("m");
         lib.linkSystemLibrary("pthread");


### PR DESCRIPTION
Because the optimize option difference between C/C++ and Zig compiler, we got a lot of `Illegal instruction at address 0x10fa2c158` issues, it seems it be ignored by C/C++ compiler. Currently I found the only way to fix that is to add `-fno-sanitize=undefined` in the build.zig. Any other thoughts to fix?

If we don't add `-fno-sanitize=undefined`,  `zig build test` and `zig build test -Doptimize=ReleaseFast` works fine in the zig-libp2p project, only `zig build test -Doptimize=ReleaseSafe` trigger the error.