### PR TITLE
chore: add ci and fix some trivial problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+env:
+    ZIG_VERSION: 0.14.1
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          # macOS builds
+          - os: macos-latest
+            target: aarch64-macos-none
+          - os: macos-latest
+            target: x86_64-macos-none
+          # Linux builds
+          - os: ubuntu-latest
+            target: aarch64-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-linux-gnu
+      fail-fast: false
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        id: setup-zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Cache Zig installation
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.setup-zig.outputs.install-path }}
+          key: ${{ runner.os }}-zig-${{ env.ZIG_VERSION }}
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            zig-cache
+            ~/.cache/zig
+          key: ${{ runner.os }}-${{ matrix.target }}-zig-build-${{ hashFiles('build.zig', 'build.zig.zon') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-zig-build-
+            
+      - name: Formatting
+        run: zig fmt --check .
+
+      # TODO: uncomment when tests are implemented
+      # - name: Unit testing
+      #   run: zig build test -Dtarget=${{matrix.target}} --summary all
+
+      - name: Building
+        run: zig build -Dtarget=${{matrix.target}} -Doptimize=ReleaseFast --summary all

--- a/build.zig
+++ b/build.zig
@@ -20,6 +20,10 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    const zlib = b.dependency("zlib", .{
+        .target = target,
+        .optimize = optimize,
+    });
 
     const ssl = boringssl.artifact("ssl");
     const crypto = boringssl.artifact("crypto");
@@ -41,6 +45,8 @@ pub fn build(b: *std.Build) void {
 
     lib.linkLibrary(ssl);
     lib.linkLibrary(crypto);
+    lib.linkLibrary(zlib.artifact("z"));
+    lib.addIncludePath(zlib.path("src"));
     lib.addIncludePath(lshpack_dep.path("deps/xxhash"));
     lib.addIncludePath(lsqpack_dep.path("deps/xxhash"));
     lib.addIncludePath(lshpack_dep.path(""));
@@ -152,5 +158,4 @@ const lsquic_files: []const []const u8 = &.{
     "lsquic_varint.c",
     "lsquic_version.c",
     "lsquic_xxhash.c",
-    "lsquic_global.c",
 };


### PR DESCRIPTION
This pull request introduces a new CI workflow for building and testing the project, along with updates to the build system to include a new `zlib` dependency. Below are the most important changes:

close #2

### CI Workflow Setup:
* Added a new GitHub Actions workflow in `.github/workflows/ci.yml` to automate builds for macOS and Linux, targeting both `aarch64` and `x86_64` architectures. It includes steps for setting up Zig, caching dependencies, formatting checks, and building the project. Unit testing is currently commented out as a placeholder for future implementation.

### Build System Updates:
* Updated the `build.zig` file to include `zlib` as a dependency, specifying its target and optimization settings.
* Modified the build script to link the `zlib` library and include its source path in the build configuration.

### Codebase Simplification:
* Removed the unused file `lsquic_global.c` from the `lsquic_files` array in `build.zig`.